### PR TITLE
fix(cbor): canonicalize CBOR map key order

### DIFF
--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -299,12 +299,17 @@ export async function createCredential(options: any): Promise<any> {
     );
     logAuth('Client data JSON created');
 
-    // Encode attestation object
-    const attestationObject = WebAuthnCBOR.encode({
-      fmt: 'none',
-      authData: authenticatorData,
-      attStmt: {},
-    });
+    // Build attestationObject as a Map (not a plain object).
+    // Our CBOR encoder sorts map keys by the bytewise lexicographic order of
+    // their CBOR encodings (RFC 8949 §4.2.1), which matches CTAP2’s canonical
+    // CBOR expectations for string keys. For "fmt", "attStmt", and "authData",
+    // this yields the required key order "fmt" → "attStmt" → "authData".
+    const attestationMap = new Map<string, any>([
+      ['fmt', 'none'],
+      ['attStmt', new Map()],
+      ['authData', authenticatorData],
+    ]);
+    const attestationObject = WebAuthnCBOR.encode(attestationMap);
     logAuth('Attestation object created');
 
     // Construct the response


### PR DESCRIPTION
**Deterministic CBOR map key ordering:**

- CBOR map keys are now sorted by the bytewise lexicographic order of their deterministic CBOR encodings ([RFC 8949](https://www.rfc-editor.org/rfc/rfc8949.html#section-4.2.1)).

- For WebAuthn structures like `attestationObject`, `attStmt`, and `COSE_Key` — which only use string and integer map keys — this matches CTAP2’s canonical CBOR requirements.

- The attestation object is now built using an explicit `Map` and encoded with that deterministic ordering, so `attestationObject` is always emitted with a consistent key order (`fmt` → `attStmt` → `authData`).