### PR TITLE
refactor(store): remove redundant private key encryption

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,6 @@ export interface StoredCredential {
   credentialId: string;
   rpId: string;
   privateKey: string;
-  iv: string;
   userHandle: string;
   publicKeyAlgorithm: number;
   counter: number;


### PR DESCRIPTION
The private key was encrypted twice with the same master key: first on its own, then again as part of the whole credential record.

- Remove inner encryption when saving private key
- Remove inner decryption when loading private key
- Remove `iv` field from stored credential `data`

This changes the storage format — existing passkeys will need to be re-registered.